### PR TITLE
Feature/opsimfield stacker

### DIFF
--- a/python/lsst/sims/survey/fields/fields_database.py
+++ b/python/lsst/sims/survey/fields/fields_database.py
@@ -101,6 +101,30 @@ class FieldsDatabase(object):
 
         return numpy.array(ra), numpy.array(dec)
 
+    def get_id_ra_dec_arrays(self, query):
+        """Retrieve lists of fieldId, RA and Dec.
+
+        Parameters
+        ----------
+        query : str
+            The query for field retrieval.
+
+        Returns
+        -------
+        numpy.array, numpy.array, numpy.array
+            The arrays of fieldId, RA and Dec.
+        """
+        rows = self.get_rows(query)
+        fieldId = []
+        ra = []
+        dec = []
+        for row in rows:
+            fieldId.append(int(row[0]))
+            ra.append(row[2])
+            dec.append(row[3])
+
+        return numpy.array(fieldId, dtype=int), numpy.array(ra), numpy.array(dec)
+
     def get_rows(self, query):
         """Get the rows from a query.
 

--- a/tests/test_field_database.py
+++ b/tests/test_field_database.py
@@ -26,12 +26,11 @@ userRegion = 180.00,-87.57,0.03"""
         self.assertAlmostEqual(dec[1], -87.57, delta=1e-2)
 
     def test_get_id_ra_dec_arrays(self):
-        fields = self.fields_db.get_id_ra_dec_arrays(self.query)
-        self.assertTrue(all([field_name in fields.dtype.names for field_name in ['fieldId', 'ra', 'dec']]))
-        self.assertEqual(fields['ra'][1], 180.0)
-        self.assertEqual(fields['fieldId'][1], 2)
-        self.assertNotEqual(fields['fieldId'][0], 0)
-        self.assertAlmostEqual(fields['dec'][1], -87.57, delta=1e-2)
+        fieldid, ra, dec = self.fields_db.get_id_ra_dec_arrays(self.query)
+        self.assertEqual(ra[1], 180.0)
+        self.assertEqual(fieldid[1], 2)
+        self.assertNotEqual(fieldid[0], 0)
+        self.assertAlmostEqual(dec[1], -87.57, delta=1e-2)
 
     def test_get_rows(self):
         rows = self.fields_db.get_rows(self.query)

--- a/tests/test_field_database.py
+++ b/tests/test_field_database.py
@@ -25,6 +25,14 @@ userRegion = 180.00,-87.57,0.03"""
         self.assertEqual(ra[1], 180.0)
         self.assertAlmostEqual(dec[1], -87.57, delta=1e-2)
 
+    def test_get_id_ra_dec_arrays(self):
+        fields = self.fields_db.get_id_ra_dec_arrays(self.query)
+        self.assertTrue(all([field_name in fields.dtype.names for field_name in ['fieldId', 'ra', 'dec']]))
+        self.assertEqual(fields['ra'][1], 180.0)
+        self.assertEqual(fields['fieldId'][1], 2)
+        self.assertNotEqual(fields['fieldId'][0], 0)
+        self.assertAlmostEqual(fields['dec'][1], -87.57, delta=1e-2)
+
     def test_get_rows(self):
         rows = self.fields_db.get_rows(self.query)
         self.assertIsInstance(rows, list)


### PR DESCRIPTION
Adds an utility function to return fieldid, ra and dec. This is used on MAF for generating a OpSimFieldStacker. 